### PR TITLE
Space Travelers' Hub: Actions and reducers

### DIFF
--- a/src/components/features/dragons.js
+++ b/src/components/features/dragons.js
@@ -37,7 +37,7 @@ function Dragons() {
                     {' '}
                     {dragon.description}
                   </div>
-                  {!dragon.reserved && <button onClick={() => handleReserveBtn(dragon.id)} className="dragonBtn" type="submit">Reserve Rocket</button> }
+                  {!dragon.reserved && <button onClick={() => handleReserveBtn(dragon.id)} className="dragonBtn" type="submit">Reserve Dragon</button> }
                   {dragon.reserved && <button onClick={() => handleCancelBtn(dragon.id)} className="cancelBtn" type="submit">Cancel Reservation</button> }
                 </div>
               </li>

--- a/src/components/features/dragons.js
+++ b/src/components/features/dragons.js
@@ -1,21 +1,23 @@
 import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { getDragonData } from '../../redux/dragons/dragonsSlice';
+import { getDragonData, reserveD, cancelD } from '../../redux/dragons/dragonsSlice';
 import '../styles/dragonStyle.css';
 
 function Dragons() {
-  const { dragons, loading } = useSelector((state) => state.dragons);
+  const dragons = useSelector((state) => state.dragons.dragon);
   const dispatch = useDispatch();
 
   useEffect(() => {
     dispatch(getDragonData());
   }, [dispatch]);
 
-  if (loading) {
-    return (
-      <div>Loading</div>
-    );
-  }
+  const handleReserveBtn = (id) => {
+    dispatch(reserveD(id));
+  };
+  const handleCancelBtn = (id) => {
+    dispatch(cancelD(id));
+  };
+
   return (
     <ul>
       {
@@ -25,10 +27,18 @@ function Dragons() {
                   <img className="dragonimg" alt="dragons" src={dragon.flickr_images} />
                 </div>
                 <div className="dragonDetails">
-                  <h3>{dragon.name}</h3>
+                  <h3>
+                    {dragon.name}
+                    {dragon.reserved}
+                  </h3>
                   <h4>{dragon.type}</h4>
-                  <div>{dragon.description}</div>
-                  <button className="dragonBtn" type="submit">Reserve Dragon</button>
+                  <div>
+                    {dragon.reserved && (<span className="reserved"> Reserved </span>)}
+                    {' '}
+                    {dragon.description}
+                  </div>
+                  {!dragon.reserved && <button onClick={() => handleReserveBtn(dragon.id)} className="dragonBtn" type="submit">Reserve Rocket</button> }
+                  {dragon.reserved && <button onClick={() => handleCancelBtn(dragon.id)} className="cancelBtn" type="submit">Cancel Reservation</button> }
                 </div>
               </li>
             ))

--- a/src/components/styles/dragonStyle.css
+++ b/src/components/styles/dragonStyle.css
@@ -29,3 +29,26 @@
   border: none;
   font-size: 18px;
 }
+
+.cancelBtn {
+
+  width: 180px;
+  height: 40px;
+  background: none;
+  border: 2px solid gray;
+  color: gray;
+  font-size: 18px;
+  border-radius: 10px;
+}
+
+.reserved {
+  height: 10px;
+    border-radius: 10px;
+    color: white;
+    background: green;
+}
+.reservecont {
+  height: auto;
+  border: 2px solid red;
+}
+

--- a/src/redux/dragons/dragonsSlice.js
+++ b/src/redux/dragons/dragonsSlice.js
@@ -17,6 +17,40 @@ const initialState = {
 const dragonsSlice = createSlice({
   name: 'dragons',
   initialState,
+
+  reducers: {
+    reserveD: (state, action) => {
+      const newDragon = state.dragon.map((dragon) => {
+        if (action.payload !== dragon.id) {
+          return dragon;
+        }
+        return {
+          ...dragon,
+          reserved: true,
+        };
+      });
+      return {
+        ...state,
+        dragon: newDragon,
+      };
+    },
+    cancelD: (state, action) => {
+      const newDragon = state.dragon.map((dragon) => {
+        if (action.payload !== dragon.id) {
+          return dragon;
+        }
+        return {
+          ...dragon,
+          reserved: false,
+        };
+      });
+      return {
+        ...state,
+        dragon: newDragon,
+      };
+    },
+  },
+
   extraReducers: (builder) => {
     builder.addCase(getDragonData.pending, (state) => ({
       ...state,
@@ -26,7 +60,8 @@ const dragonsSlice = createSlice({
     builder.addCase(getDragonData.fulfilled, (state, action) => ({
       ...state,
       loading: false,
-      dragons: action.payload,
+      reserved: false,
+      dragon: action.payload,
     }));
 
     builder.addCase(getDragonData.rejected, (state, action) => ({
@@ -36,5 +71,7 @@ const dragonsSlice = createSlice({
     }));
   },
 });
+
+export const { reserveD, cancelD } = dragonsSlice.actions;
 
 export default dragonsSlice.reducer;


### PR DESCRIPTION
### Activities

- Wrote reducer: 'reserveD'  for booking dragons, and returns a new state object with all dragons, but the selected dragon having an extra key reserved with its value set to true
- Wrote reducer: cancelD for canceling dragons and returns a new state object with all dragons, but the selected dragon having an extra key reserved with its value set to false
- Did conditional components rendering: Dragons that have already been reserved  show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve dragon"